### PR TITLE
Fixed include services not working when conf.IsSkipSelfCall

### DIFF
--- a/diagram.go
+++ b/diagram.go
@@ -120,8 +120,8 @@ func extractMethodName(s *span) string {
 }
 
 func shouldSkipSpan(s *span, caller, callee string, conf config) bool {
-	if conf.IsSkipSelfCall {
-		return caller == callee
+	if conf.IsSkipSelfCall && caller == callee {
+		return true
 	}
 	if len(conf.IncludeServices) > 0 {
 		return !contains(conf.IncludeServices, s.Service)

--- a/example/config.yaml
+++ b/example/config.yaml
@@ -7,3 +7,4 @@ grpc_serivce_alias:
   /foo.bar.v1.Service: v1-service
   /foo.bar.v2.Service: v2-service
   /foo.bar.v3.Service: v3-service
+  /foo.bar.v4.Service: v4-service

--- a/example/trace.json
+++ b/example/trace.json
@@ -9,7 +9,7 @@
                 "meta": {
                     "grpc.method.name": "/foo.bar.v2.Service/Ping"
                 },
-                "children_ids": ["1234567892"],
+                "children_ids": ["1234567892", "1234567893"],
                 "type": "rpc"
             },
             "1234567891": {
@@ -27,6 +27,15 @@
                 "start": 1627781877.00000,
                 "meta": {
                     "grpc.method.name": "/foo.bar.v3.Service/Pong"
+                },
+                "type": "rpc"
+            },
+            "1234567893": {
+                "span_id": "1234567893",
+                "service": "v3-service",
+                "start": 1627781878.00000,
+                "meta": {
+                    "grpc.method.name": "/foo.bar.v4.Service/Pong"
                 },
                 "type": "rpc"
             }

--- a/testdata/simple/config.yaml
+++ b/testdata/simple/config.yaml
@@ -7,3 +7,4 @@ grpc_serivce_alias:
   /foo.bar.v1.Service: v1-service
   /foo.bar.v2.Service: v2-service
   /foo.bar.v3.Service: v3-service
+  /foo.bar.v4.Service: v4-service

--- a/testdata/simple/trace.json
+++ b/testdata/simple/trace.json
@@ -9,7 +9,7 @@
                 "meta": {
                     "grpc.method.name": "/foo.bar.v2.Service/Ping"
                 },
-                "children_ids": ["1234567892"],
+                "children_ids": ["1234567892", "1234567893"],
                 "type": "rpc"
             },
             "1234567891": {
@@ -27,6 +27,15 @@
                 "start": 1627781877.00000,
                 "meta": {
                     "grpc.method.name": "/foo.bar.v3.Service/Pong"
+                },
+                "type": "rpc"
+            },
+            "1234567893": {
+                "span_id": "1234567893",
+                "service": "v3-service",
+                "start": 1627781878.00000,
+                "meta": {
+                    "grpc.method.name": "/foo.bar.v4.Service/Pong"
                 },
                 "type": "rpc"
             }


### PR DESCRIPTION
hey,
When the `.IsSkipSelfCall` is set, the `IncludeServices` were ignored completely

This should fix the linked issue. 

Fixes https://github.com/upamune/jigsaw/issues/12