### PR TITLE
Update javascript in `upamune.github.io/jigsaw` to use new api endpoint

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -30,7 +30,7 @@
             👇 Just drag and drop this onto your bookmark bar!
         </p>
         <p>
-            <a href="javascript:(function()%7Bconst%20origin%20%3D%20window.location.origin%3B%0Aconst%20params%20%3D%20new%20URLSearchParams(window.location.search)%3B%0Alet%20traceID%20%3D%20params.get('traceID')%3B%0Aif%20(traceID%20%3D%3D%3D%20null)%20%7B%0A%20%20const%20path%20%3D%20window.location.pathname%3B%0A%20%20if%20(!path.startsWith('%2Fapm%2Ftrace%2F'))%20return%3B%0A%20%20traceID%20%3D%20path.replace('%2Fapm%2Ftrace%2F'%2C%20'')%3B%0A%7D%0Aconst%20traceURL%20%3D%20%60%24%7Borigin%7D%2Fapi%2Fv1%2Ftrace%2F%24%7BtraceID%7D%60%3B%0Awindow.open(traceURL%2C%20'_blank').focus()%3B%7D)()%3B">trace2json</a>
+            <a href="javascript:(function()%7Bconst%20origin%20%3D%20window.location.origin%3B%0Aconst%20params%20%3D%20new%20URLSearchParams(window.location.search)%3B%0Alet%20traceID%20%3D%20params.get('traceID')%3B%0Aif%20(traceID%20%3D%3D%3D%20null)%20%7B%0A%20%20const%20path%20%3D%20window.location.pathname%3B%0A%20%20if%20(!path.startsWith('%2Fapm%2Ftrace%2F'))%20return%3B%0A%20%20traceID%20%3D%20path.replace('%2Fapm%2Ftrace%2F'%2C%20'')%3B%0A%7D%0Aconst%20traceURL%20%3D%20%60%24%7Borigin%7D%2Fapi%2Fui%2Ftrace%2F%24%7BtraceID%7D%60%3B%0Awindow.open(traceURL%2C%20'_blank').focus()%3B%7D)()%3B">trace2json</a>
         </p>
         <p>
             Click it when you're on the Datadog Trace details page!
@@ -48,7 +48,7 @@ if (traceID === null) {
   if (!path.startsWith('/apm/trace/')) return;
   traceID = path.replace('/apm/trace/', '');
 }
-const traceURL = `${origin}/api/v1/trace/${traceID}`;
+const traceURL = `${origin}/api/ui/trace/${traceID}`;
 window.open(traceURL, '_blank').focus();</code>
         </pre>
     </div>


### PR DESCRIPTION
Update the script bookmark to use the new endpoint `/api/ui/trace/${traceID}` which supports both legacy 64-bit trace ids (encoded as a decimal string) and the new 128-bit trace ids (encoded as hexadecimal strings). The older `/api/v1/trace/${traceID}` endpoint only supports legacy 64-bit trace ids.